### PR TITLE
npm install fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "Big Query"
   ],
   "author": "Doug Murphy",
-  "license": " ",
   "dependencies": {
     "@google-cloud/bigquery": "^0.3.0",
     "async": "^2.1.2",


### PR DESCRIPTION
due to empty license string
npm WARN Invalid argument. Expected non-empty string.